### PR TITLE
Use --no-sandbox for Google Chrome

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,6 @@ It is recommended to run ``nvget`` using the Docker image hosted on `DockerHub <
   # Download the file.
   nvget-docker "https://developer.nvidia.com/compute/machine-learning/nccl/secure/v2.1/prod/nccl_2.1.2-1+cuda8.0_x86_64"
 
-Due to the limitation of Google Chrome and ChromeDriver, ``nvget`` cannot be run as a root user.
-If you are running the image in ``root`` user privilege, replace ``${UID}`` with any other non-root UID.
-
 Development
 -----------
 

--- a/nvget/controller.py
+++ b/nvget/controller.py
@@ -27,6 +27,7 @@ class Controller(object):
         options = selenium.webdriver.ChromeOptions()
         options.binary_location = self._chrome_path
         options.add_argument('headless')
+        options.add_argument('--no-sandbox')
 
         driver = selenium.webdriver.Chrome(
             executable_path=self._driver_path,


### PR DESCRIPTION
To address the error when launching google-chrome in recent Docker without `--privileged`:

```
Logging in...
Traceback (most recent call last):
  File "/usr/local/bin/nvget", line 9, in <module>
    load_entry_point('nvget==0.1.0', 'console_scripts', 'nvget')()
  File "/usr/local/lib/python2.7/dist-packages/nvget/cli.py", line 62, in nvget
    ctrl.login(args.user, args.password)
  File "/usr/local/lib/python2.7/dist-packages/nvget/controller.py", line 33, in login
    chrome_options=options)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/chrome/webdriver.py", line 75, in __init__
    desired_capabilities=desired_capabilities)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 156, in __init__
    self.start_session(capabilities, browser_profile)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 251, in start_session
    response = self.execute(Command.NEW_SESSION, parameters)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 320, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: unknown error: Chrome failed to start: crashed
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /opt/google/chrome/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
  (Driver info: chromedriver=2.41.578700 (2f1ed5f9343c13f73144538f15c00b370eda6706),platform=Linux 4.4.0-135-generic x86_64)
```

The root cause is:

```
$ /opt/google/chrome/google-chrome
Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted
```

`--no-sandbox` also allows running as root user.